### PR TITLE
Fix: Add setupTitle() to format didSet for titleAlwaysVisible

### DIFF
--- a/Sources/AnimatedField/AnimatedField.swift
+++ b/Sources/AnimatedField/AnimatedField.swift
@@ -353,10 +353,11 @@ open class AnimatedField: UIView {
                                    ])
                 attributedPlaceholder = placeholderText
             }
+            setupTitle()
             layoutIfNeeded()
         }
     }
-    
+
     /// The text content of the field.
     ///
     /// ## Important Behavior Notes:


### PR DESCRIPTION
## Summary
- Adds `setupTitle()` call to the `format` property `didSet` observer
- Fixes `titleLabel.alpha` not updating when `format.titleAlwaysVisible` is changed after initialization
- Unblocks iOS team removal of 12 KVC workarounds (XIOS-0565)

## Changes Made
**`Sources/AnimatedField/AnimatedField.swift`** (+2, -1)
- Added `setupTitle()` call before `layoutIfNeeded()` in `format` `didSet` (line 356)

## Root Cause
`setupTitle()` was only called during `commonInit()`. When `format` was reassigned post-init, the `didSet` updated fonts, colors, and constraints but never called `setupTitle()`, so `titleLabel.alpha` remained at 0.0 even when `titleAlwaysVisible` was `true`.

## Impact
- **Files changed:** 1 | **Lines:** +2 -1
- **Risk:** LOW — additive one-line change to existing didSet
- **Breaking changes:** None

## Test Plan
- [ ] Set `format.titleAlwaysVisible = true` after init — title should be visible
- [ ] Set `format.titleAlwaysVisible = false` after init — title should hide
- [ ] Verify `commonInit()` behavior unchanged (title visible/hidden on first load)
- [ ] Regression: confirm format property changes still apply all other styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)