### PR TITLE
Fix: Cursor positioning and text setter guard during editing

### DIFF
--- a/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
+++ b/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
@@ -102,13 +102,48 @@ extension AnimatedField: UITextFieldDelegate {
         }
 
         // Calculate cursor position AFTER formatting to account for auto-inserted characters
-        var offset = range.location + range.length + string.count
+        var offset: Int
         if string.count == 0 {
-            offset -= range.length
+            // Deletion: cursor stays at deletion point
+            offset = range.location
         } else {
-            // If formatText() added characters, adjust cursor to end of text
-            // This ensures cursor is placed after the newly typed character and any auto-inserted separators
-            offset = textField.text?.count ?? offset
+            let formatPattern = textField.formatPattern
+            if !formatPattern.isEmpty {
+                // Map cursor from formatted-text coordinates to raw-content coordinates,
+                // advance by typed characters, then map back to formatted coordinates.
+                // Pattern placeholders (#, @, a, A, *) are content slots; everything else
+                // is a literal separator inserted by formatText().
+                let placeholders: Set<Character> = ["#", "@", "a", "A", "*"]
+
+                // Step 1: count content characters before range.location in the pattern
+                var rawLocation = 0
+                for i in 0..<min(range.location, formatPattern.count) {
+                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: i)
+                    if placeholders.contains(formatPattern[idx]) {
+                        rawLocation += 1
+                    }
+                }
+                let rawCursor = rawLocation + string.count
+
+                // Step 2: walk the pattern to find the formatted position of rawCursor
+                var contentCount = 0
+                offset = formatPattern.count
+                for i in 0..<formatPattern.count {
+                    if contentCount >= rawCursor {
+                        offset = i
+                        break
+                    }
+                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: i)
+                    if placeholders.contains(formatPattern[idx]) {
+                        contentCount += 1
+                    }
+                }
+            } else {
+                // No format pattern: simple cursor positioning
+                offset = range.location + string.count
+            }
+            // Clamp to actual text length
+            offset = min(offset, textField.text?.count ?? offset)
         }
         if let newPosition = textField.position(from: textField.beginningOfDocument, offset: offset) {
             textField.selectedTextRange = textField.textRange(from: newPosition, to: newPosition)

--- a/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
+++ b/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
@@ -117,8 +117,8 @@ extension AnimatedField: UITextFieldDelegate {
 
                 // Step 1: count content characters before range.location in the pattern
                 var rawLocation = 0
-                for i in 0..<min(range.location, formatPattern.count) {
-                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: i)
+                for pos in 0..<min(range.location, formatPattern.count) {
+                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: pos)
                     if placeholders.contains(formatPattern[idx]) {
                         rawLocation += 1
                     }
@@ -128,12 +128,12 @@ extension AnimatedField: UITextFieldDelegate {
                 // Step 2: walk the pattern to find the formatted position of rawCursor
                 var contentCount = 0
                 offset = formatPattern.count
-                for i in 0..<formatPattern.count {
+                for pos in 0..<formatPattern.count {
                     if contentCount >= rawCursor {
-                        offset = i
+                        offset = pos
                         break
                     }
-                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: i)
+                    let idx = formatPattern.index(formatPattern.startIndex, offsetBy: pos)
                     if placeholders.contains(formatPattern[idx]) {
                         contentCount += 1
                     }

--- a/Sources/AnimatedField/AnimatedField.swift
+++ b/Sources/AnimatedField/AnimatedField.swift
@@ -383,13 +383,17 @@ open class AnimatedField: UIView {
     ///   if delegates perform actions on text changes.
     /// - If validation fails, text may not be set as expected (check return value of delegates).
     /// - For multiline fields, updates textView state and placeholder management.
+    /// - **Ignored during active editing** (`isFirstResponder`). Internal typing sets the
+    ///   underlying UITextField/UITextView `.text` directly; this setter is only for external callers.
     open var text: String? {
         get {
             return textField.isHidden ? (textView.text == placeholder && textView.textColor == format.placeholderColor ? "" : textView.text) : textField.text
         }
         set {
             if !textField.isHidden {
-                // Skip if value hasn't changed — prevents cursor reset during active editing
+                // Don't overwrite text during active editing — preserves cursor position.
+                // Internal typing goes through UITextField.text directly, not this setter.
+                guard !textField.isFirstResponder else { return }
                 guard textField.text != newValue else { return }
                 let range = NSRange(location: 0, length: newValue?.count ?? 0)
                 let should = textField(textField,
@@ -402,7 +406,9 @@ open class AnimatedField: UIView {
                 textField.text = nil
             }
             if !textView.isHidden {
-                // Skip if value hasn't changed — prevents cursor reset during active editing
+                // Don't overwrite text during active editing — preserves cursor position.
+                // Internal typing goes through UITextView.text directly, not this setter.
+                guard !textView.isFirstResponder else { return }
                 guard textView.text != newValue else { return }
                 let range = NSRange(location: 0, length: newValue?.count ?? 0)
                 let should = textView(textView,


### PR DESCRIPTION
## Summary
- **Bug 1:** Fixes mid-string insertion moving cursor to end of text in formatted fields
- **Bug 2:** Guards text setter with `isFirstResponder` to prevent external overwrites during editing
- Unblocks iOS team removal of 12+ cell-level workarounds (XIOS-0576)

## Changes Made

**`Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift`** (+42, -7)
- Replaced unconditional `offset = textField.text?.count` (line 111) with format-pattern-aware cursor mapping
- Maps cursor between formatted coordinates (with separators) and raw content coordinates (without)
- Uses SwiftMaskTextfield's `formatPattern` placeholder chars (`#`, `@`, `a`, `A`, `*`) to identify content vs separator positions
- Falls back to simple `range.location + string.count` for fields without format patterns
- Deletion behavior unchanged (cursor stays at deletion point)

**`Sources/AnimatedField/AnimatedField.swift`** (+6, -2)
- Added `guard !textField.isFirstResponder else { return }` in text setter (textField path)
- Added `guard !textView.isFirstResponder else { return }` in text setter (textView path)
- Updated doc comment to document `isFirstResponder` behavior
- Safe because internal typing sets `UITextField.text` / `UITextView.text` directly, never this computed setter

## Root Causes

**Bug 1:** `shouldChangeCharactersIn` calculated cursor offset as `range.location + range.length + string.count`, then unconditionally overrode it with `textField.text?.count` (end of text) for any insertion. This discarded the correct insertion point and ignored format separator positions.

**Bug 2:** The `text` computed property setter only checked for same-value (`textField.text != newValue`). When a cell's `data didSet` fired with a different value during editing, it triggered `shouldChangeCharactersIn` → `formatText()` → cursor reset (Bug 1).

## Impact
- **Files changed:** 2 | **Lines:** +48 -7
- **Risk:** MEDIUM — cursor math changes affect all formatted fields; text setter guard changes programmatic-set behavior
- **Breaking changes:** External callers can no longer set `.text` while the field is first responder. This is intentional — the previous behavior caused cursor resets.

## Test Plan
- [ ] **Bug 1 — Formatted field mid-insertion:** Place cursor in middle of `####-####-####-####` field, type digit → cursor stays after typed digit (not end)
- [ ] **Bug 1 — Separator boundary:** Type 4th digit in `####-####` → cursor jumps past dash to position 6
- [ ] **Bug 1 — Non-formatted field:** Type in plain text field → cursor stays at insertion point
- [ ] **Bug 1 — Deletion:** Delete character in formatted field → cursor stays at deletion point
- [ ] **Bug 2 — Active editing guard:** While typing in field, trigger cell reload → text not overwritten, cursor not reset
- [ ] **Bug 2 — Programmatic set when not editing:** Set `.text` when field is not first responder → works normally
- [ ] **Regression:** FunCard number entry, support ticket forms, personal details editing

## References
- iOS Kanban: XIOS-0576
- Handoff from iOS team (Beverly Crusher)
- Affects 50+ cells in MainEventApp-iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)