### PR TITLE
Fix: Account for prefix in cursor positioning

### DIFF
--- a/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
+++ b/Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift
@@ -115,9 +115,14 @@ extension AnimatedField: UITextFieldDelegate {
                 // is a literal separator inserted by formatText().
                 let placeholders: Set<Character> = ["#", "@", "a", "A", "*"]
 
-                // Step 1: count content characters before range.location in the pattern
+                // Displayed text = prefix + formatted. range.location is in displayed
+                // coordinates, but the pattern only covers the formatted portion.
+                let prefixLen = textField.prefix.count
+                let patternLocation = max(range.location - prefixLen, 0)
+
+                // Step 1: count content characters before patternLocation in the pattern
                 var rawLocation = 0
-                for pos in 0..<min(range.location, formatPattern.count) {
+                for pos in 0..<min(patternLocation, formatPattern.count) {
                     let idx = formatPattern.index(formatPattern.startIndex, offsetBy: pos)
                     if placeholders.contains(formatPattern[idx]) {
                         rawLocation += 1
@@ -127,10 +132,10 @@ extension AnimatedField: UITextFieldDelegate {
 
                 // Step 2: walk the pattern to find the formatted position of rawCursor
                 var contentCount = 0
-                offset = formatPattern.count
+                var patternOffset = formatPattern.count
                 for pos in 0..<formatPattern.count {
                     if contentCount >= rawCursor {
-                        offset = pos
+                        patternOffset = pos
                         break
                     }
                     let idx = formatPattern.index(formatPattern.startIndex, offsetBy: pos)
@@ -138,6 +143,8 @@ extension AnimatedField: UITextFieldDelegate {
                         contentCount += 1
                     }
                 }
+                // Add prefix back to get displayed-text offset
+                offset = patternOffset + prefixLen
             } else {
                 // No format pattern: simple cursor positioning
                 offset = range.location + string.count


### PR DESCRIPTION
## Summary
- Fixes cursor positioning when `SwiftMaskTextfield.prefix` is non-empty
- `range.location` from `shouldChangeCharactersIn` includes prefix characters, but `formatPattern` does not — the offset must be adjusted before pattern indexing
- Follow-up to PR #4 (identified by code review)

## Changes Made
**`Sources/AnimatedField/AnimatedField+TextFieldDelegate.swift`** (+11, -4)
- Added `prefixLen` calculation from `textField.prefix.count`
- Subtract prefix from `range.location` before Step 1 pattern walk (`patternLocation`)
- Renamed `offset` to `patternOffset` in Step 2 for clarity
- Add prefix back after Step 2 to get displayed-text offset
- Clamped `patternLocation` with `max(0)` to handle cursor-inside-prefix edge case

## Impact
- **Files changed:** 1 | **Lines:** +11 -4
- **Risk:** LOW — additive adjustment, no change when prefix is empty (default)
- **Breaking changes:** None

## Test Plan
- [ ] Field with no prefix — verify identical behavior to 3.2.0
- [ ] Field with prefix (e.g., "US-" + `####-####`) — cursor stays at correct position after typing
- [ ] Cursor placed inside prefix region — no crash, reasonable positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)